### PR TITLE
Feature/xxxx wifi101

### DIFF
--- a/examples/wifi101/arduino_secrets.h
+++ b/examples/wifi101/arduino_secrets.h
@@ -1,0 +1,2 @@
+#define SECRET_SSID "Flesher1"
+#define SECRET_PASS "Foxesden4"

--- a/examples/wifi101/wifi101.ino
+++ b/examples/wifi101/wifi101.ino
@@ -1,0 +1,50 @@
+#include <simpleRPC.h>
+#include <SPI.h>
+#include <WiFi101.h>
+#include "arduino_secrets.h"
+
+WiFi101IO io;
+char ssid[] = SECRET_SSID;    // your network SSID (name)
+char pass[] = SECRET_PASS;    // your network password (use for WPA, or use as key for WEP)
+
+byte ping(byte data) {
+  return data;
+}
+
+void setup(void) {
+  Serial.begin(9600);
+  WiFi.setPins(8, 7, 4, 2);
+  while (!connectWiFi()) {
+    delay(10);
+  }
+  printWiFiStatus();
+}
+
+void connectWiFi() {
+  static int status = WL_IDLE_STATUS;
+  if (WiFi.status() == WL_NO_SHIELD) {
+    return false;
+  }
+  if (status != WL_CONNECTED) {
+    status = WiFi.begin(ssid, password);
+  }
+  return status == WL_CONNECTED;
+}
+
+void printWiFiStatus() {
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+  IPAddress ip = WiFi.localIP();
+  Serial.print("IP Address: ");
+  Serial.println(ip);
+  long rssi = WiFi.RSSI();
+  Serial.print("signal strength (RSSI):");
+  Serial.print(rssi);
+  Serial.println(" dBm");
+}
+
+void loop(void) {
+  interface(
+    io,
+    ping, F("ping: Echo a value. @data: Value. @return: Value of data."));
+}

--- a/examples/wifi101/wifi101.ino
+++ b/examples/wifi101/wifi101.ino
@@ -3,9 +3,10 @@
 #include <WiFi101.h>
 #include "arduino_secrets.h"
 
-WiFi101IO io;
 char ssid[] = SECRET_SSID;    // your network SSID (name)
 char pass[] = SECRET_PASS;    // your network password (use for WPA, or use as key for WEP)
+WiFiClient wc;
+WiFi101IO io;
 
 byte ping(byte data) {
   return data;
@@ -18,6 +19,8 @@ void setup(void) {
     delay(10);
   }
   printWiFiStatus();
+  wc.connect(IPAddress("192.168.1.218"), 11511);
+  io.begin(wc);
 }
 
 void connectWiFi() {

--- a/examples/wifi101/wifi101.ino
+++ b/examples/wifi101/wifi101.ino
@@ -1,11 +1,9 @@
 #include <simpleRPC.h>
-#include <SPI.h>
 #include <WiFi101.h>
 #include "arduino_secrets.h"
 
 char ssid[] = SECRET_SSID;    // your network SSID (name)
 char pass[] = SECRET_PASS;    // your network password (use for WPA, or use as key for WEP)
-WiFiClient wc;
 WiFi101IO io;
 
 byte ping(byte data) {
@@ -14,36 +12,9 @@ byte ping(byte data) {
 
 void setup(void) {
   Serial.begin(9600);
-  WiFi.setPins(8, 7, 4, 2);
-  while (!connectWiFi()) {
-    delay(10);
-  }
-  printWiFiStatus();
-  wc.connect(IPAddress("192.168.1.218"), 11511);
-  io.begin(wc);
-}
-
-void connectWiFi() {
-  static int status = WL_IDLE_STATUS;
-  if (WiFi.status() == WL_NO_SHIELD) {
-    return false;
-  }
-  if (status != WL_CONNECTED) {
-    status = WiFi.begin(ssid, password);
-  }
-  return status == WL_CONNECTED;
-}
-
-void printWiFiStatus() {
-  Serial.print("SSID: ");
-  Serial.println(WiFi.SSID());
-  IPAddress ip = WiFi.localIP();
-  Serial.print("IP Address: ");
-  Serial.println(ip);
-  long rssi = WiFi.RSSI();
-  Serial.print("signal strength (RSSI):");
-  Serial.print(rssi);
-  Serial.println(" dBm");
+  WiFi.setPins(8,7,4,2);
+  io.begin(ssid, pass);
+  io.printStatus(Serial);
 }
 
 void loop(void) {

--- a/src/plugins/wifi101/io.cpp
+++ b/src/plugins/wifi101/io.cpp
@@ -1,0 +1,24 @@
+#include "io.h"
+
+
+void WiFi101IO::begin(WiFiClient& wc) {
+  _wc = &wc;
+}
+
+size_t WiFi101IO::available(void) {
+  return (size_t)_wc->available();
+}
+
+size_t WiFi101IO::read(uint8_t* buffer, size_t size) {
+  if (_wc->connected()) {
+    return _wc->read(buffer, size);
+  }
+  else {
+    _wc->connect(_wc->remoteIP(), _wc->remotePort());
+  }
+  return -1;
+}
+
+size_t WiFi101IO::write(uint8_t* buffer, size_t size) {
+  return _wc->write(buffer, size);
+}

--- a/src/plugins/wifi101/io.h
+++ b/src/plugins/wifi101/io.h
@@ -1,0 +1,20 @@
+#ifndef SIMPLE_RPC_WIFI101_IO_H_
+#define SIMPLE_RPC_WIFI101_IO_H_
+
+#include <WiFi101.h>
+
+// Connect using WiFi101
+class WiFi101IO {
+  public:
+    WiFi101IO(void) {}
+    void begin(WiFiClient& wc);
+    size_t available(void);
+    size_t read(uint8_t*, size_t);
+    size_t write(uint8_t*, size_t);
+  private:
+    WiFiClient* _wc;
+};
+
+bool begin(const char* ssid, const char* password);
+
+#endif


### PR DESCRIPTION
## Pull Request Details
This is the arduino side needed to support WiFi101 ethernet devices.

## Breaking Changes
There are no breaking changes, this PR just adds an example .ino file. The `WiFiClient` class inherits from the Arduino `Client` class which inherits from the `Stream` class to provide `read`, `write` and `available` methods needed by the `Interface` class.

## Other Relevant Information
This is not working fully yet, need to add matching code in the `arduino-simple-rpc` repo. The basic strategy there is to set the device name to be something like `socket://192.168.1.151:10000` instead of `/dev/ttyACM0` and then use the pyserial `serial_for_url` function call instead of `Serial` constructor. This is working in [`jfjlaros/arduino-simple-rpc` PR #4](https://github.com/jfjlaros/arduino-simple-rpc/pull/4)