### PR TITLE
Array and String bulk write

### DIFF
--- a/src/print.tcc
+++ b/src/print.tcc
@@ -38,7 +38,7 @@ inline void rpcPrint(Stream& io, char const* data) {
 /*! \ingroup print
  * \copydoc rpcPrint(Stream&, T) */
 inline void rpcPrint(Stream& io, String& data) {
-  rpcPrint(io, data.c_str(), data.length() + 1);
+  rpcPrint(io, data.c_str());
 }
 
 /*! \ingroup print

--- a/src/print.tcc
+++ b/src/print.tcc
@@ -25,6 +25,10 @@ inline void rpcPrint(Stream& io, char* data) {
   }
 }
 
+inline void rpcPrint(Stream& io, const char* data, int len) {
+  io.write(data, len);
+}
+
 /*! \ingroup print
  * \copydoc rpcPrint(Stream&, T) */
 inline void rpcPrint(Stream& io, char const* data) {
@@ -34,7 +38,7 @@ inline void rpcPrint(Stream& io, char const* data) {
 /*! \ingroup print
  * \copydoc rpcPrint(Stream&, T) */
 inline void rpcPrint(Stream& io, String& data) {
-  rpcPrint(io, data.c_str());
+  rpcPrint(io, data.c_str(), data.length() + 1);
 }
 
 /*! \ingroup print

--- a/src/write.tcc
+++ b/src/write.tcc
@@ -54,10 +54,9 @@ void rpcWrite(Stream& io, Vector<T>* data) {
  * \copydoc rpcWrite(Stream&, T*) */
 template <class T, size_t n>
 void rpcWrite(Stream& io, Array<T, n>* data) {
-  size_t size {(*data).size()};
+  size_t size {n};
   rpcWrite(io, &size);
-  size_t totalSize = size * sizeof(T);
-  io.write(reinterpret_cast<uint8_t*>(&(*data)[0]), totalSize);
+  io.write(&((*data)[0]), size * sizeof(T));
 }
 
 

--- a/src/write.tcc
+++ b/src/write.tcc
@@ -56,9 +56,8 @@ template <class T, size_t n>
 void rpcWrite(Stream& io, Array<T, n>* data) {
   size_t size {(*data).size()};
   rpcWrite(io, &size);
-  for (size_t i {0}; i < size; ++i) {
-    rpcWrite(io, &(*data)[i]);
-  }
+  size_t totalSize = size * sizeof(T);
+  io.write(reinterpret_cast<uint8_t*>(&(*data)[0]), totalSize);
 }
 
 


### PR DESCRIPTION
## Pull Request Details
Provide details about your pull request and what it adds, fixes, or changes.

Use the underlying io.write(buf, len) methods when there are multiple items to be written.  This dramatically speeds up the transfer speeds.

## Breaking Changes
Describe what features are broken by this pull request and why, if any.

None

## Issues Fixed
Enter the issue numbers resolved by this pull request below, if any.

None

## Other Relevant Information
Provide any other important details below.

Tested on my Adafruit M0 and it's about 3X the transfer speed over the USB serial console.