### PR TITLE
Remove the size from the Array signature.

### DIFF
--- a/src/types.tcc
+++ b/src/types.tcc
@@ -170,8 +170,6 @@ void rpcTypeOf(Stream& io, Vector<T>&) {
 template <class T, size_t n>
 void rpcTypeOf(Stream& io, Array<T, n>&) {
   rpcPrint(io, '[');
-  size_t n_ {n};
-  rpcPrint(io, n_);
   T x {};
   rpcTypeOf(io, x);
   rpcPrint(io, ']');

--- a/tests/test_types.cc
+++ b/tests/test_types.cc
@@ -120,7 +120,6 @@ TEST_CASE("Array", "[types][array]") {
   Serial.reset();
   rpcTypeOf(Serial, a);
   REQUIRE(Serial.inspect<char>() == '[');
-  REQUIRE(Serial.inspect<size_t>() == 2);
   REQUIRE(Serial.inspect<String>() == "i]");
 }
 


### PR DESCRIPTION
## Pull Request Details
Provide details about your pull request and what it adds, fixes, or changes.

Remove the size from the Array signature because the Python code can't parse this.  Removing this makes it works like a Vector which can be parsed by the Python code.  The API itself is ambiguous because it can't tell what should be after a starting '['

## Breaking Changes
Describe what features are broken by this pull request and why, if any.

Signature on Array.

## Issues Fixed
Enter the issue numbers resolved by this pull request below, if any.

None

## Other Relevant Information
Provide any other important details below.
